### PR TITLE
Chore/object-hash-options

### DIFF
--- a/packages/core/src/AssetPack.ts
+++ b/packages/core/src/AssetPack.ts
@@ -7,11 +7,11 @@ import type { AssetSettings } from './pipes/PipeSystem';
 import { PipeSystem } from './pipes/PipeSystem';
 import { finalCopyPipe } from './pipes/finalCopyPipe';
 import type { AssetPackConfig } from './config';
-import objectHash from 'object-hash';
 import { Logger } from './logger/Logger';
 import { promiseAllConcurrent } from './utils/promiseAllConcurrent';
 import { path } from './utils/path';
 import merge from 'merge';
+import { generateCacheName } from './utils/generateCacheName';
 
 export class AssetPack
 {
@@ -41,10 +41,10 @@ export class AssetPack
             level: this.config.logLevel || 'info',
         });
 
-        const { pipes, cache, ...configWithoutPlugins } = this.config;
+        const { pipes, cache } = this.config;
 
         // make a hash..
-        const cacheName = [objectHash(configWithoutPlugins), ...(pipes as AssetPipe[]).map((pipe) => pipe.name)].join('-');
+        const cacheName = generateCacheName(this.config);
 
         let assetCacheData = null;
         let assetCache: AssetCache | null = null;
@@ -243,3 +243,4 @@ function normalizePath(pth: string)
 
     return pth;
 }
+

--- a/packages/core/src/utils/generateCacheName.ts
+++ b/packages/core/src/utils/generateCacheName.ts
@@ -1,10 +1,21 @@
 import type { AssetPackConfig } from '../config';
 import objectHash from 'object-hash';
 
+/**
+ * Returns a unique name based on the hash generated from the config
+ * this takes into account the following:
+ * - pipes and their options,
+ * - entry and output paths.
+ * - assetSettings options
+ * - ignore options
+ *
+ * @param options - The asset pack config
+ * @returns - A unique name based on the hash generated from the config
+ */
 export function generateCacheName(options: AssetPackConfig)
 {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { pipes, cache, ...configWithoutPlugins } = options;
+    const { pipes, cache, logLevel, ...configWithoutPlugins } = options;
 
     const optionsToHash: any = {
         ...configWithoutPlugins,

--- a/packages/core/src/utils/generateCacheName.ts
+++ b/packages/core/src/utils/generateCacheName.ts
@@ -1,0 +1,21 @@
+import type { AssetPackConfig } from '../config';
+import objectHash from 'object-hash';
+
+export function generateCacheName(options: AssetPackConfig)
+{
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { pipes, cache, ...configWithoutPlugins } = options;
+
+    const optionsToHash: any = {
+        ...configWithoutPlugins,
+    };
+
+    // get pipes
+    pipes?.flat().forEach((pipe) =>
+    {
+        optionsToHash[pipe.name] = pipe.defaultOptions;
+    });
+
+    // make a hash..
+    return objectHash(optionsToHash);
+}

--- a/packages/core/test/Utils.test.ts
+++ b/packages/core/test/Utils.test.ts
@@ -3,6 +3,7 @@ import { createFolder, createAssetPipe, getInputDir, getOutputDir } from '../../
 import type { Asset } from '../src/Asset';
 import { AssetPack } from '../src/AssetPack';
 import { extractTagsFromFileName } from '../src/utils/extractTagsFromFileName';
+import { generateCacheName } from '../src/utils/generateCacheName';
 
 describe('Utils', () =>
 {
@@ -24,7 +25,7 @@ describe('Utils', () =>
         expect(extractTagsFromFileName('test{tag1}{tag2=1&2}.json')).toEqual({ tag1: true, tag2: [1, 2] });
     });
 
-    it.only('should allow for tags to be overridden', async () =>
+    it('should allow for tags to be overridden', async () =>
     {
         const testName = 'tag-override';
         const inputDir = getInputDir(pkg, testName);
@@ -81,5 +82,51 @@ describe('Utils', () =>
         });
 
         await assetpack.run();
+    });
+
+    it('should create a unique cache name', async () =>
+    {
+        const cacheName = generateCacheName({
+            entry: 'test',
+            output: 'out',
+            pipes: [
+                {
+                    name: 'test',
+                    defaultOptions: { hi: 'there' }
+                },
+            ],
+        });
+
+        expect(cacheName).toEqual('9782a5400ded95c60849cf955508938b7efdc8a0');
+
+        // change the settings:
+
+        const cacheName2 = generateCacheName({
+            entry: 'test',
+            output: 'out',
+            pipes: [
+                {
+                    name: 'test-2',
+                    defaultOptions: { hi: 'there' }
+                },
+            ],
+        });
+
+        expect(cacheName2).toEqual('abdf0d02db2c221346e31f61331e5880deff6f4e');
+
+        // change the settings:
+
+        const cacheName3 = generateCacheName({
+            entry: 'test',
+            output: 'out',
+            pipes: [
+                {
+                    name: 'test-2',
+                    defaultOptions: { hi: 'bye!' }
+                },
+            ],
+        });
+
+        expect(cacheName3).toEqual('ab900fa81d7121ea46bd2eafe9e826633c1c48a0');
     });
 });


### PR DESCRIPTION
Now takes into account the pipe options as well as the standard options when generating a cache file name