### PR TITLE
chore(all): ensure correct options are being used

### DIFF
--- a/packages/core/src/Asset.ts
+++ b/packages/core/src/Asset.ts
@@ -31,6 +31,7 @@ export class Asset
     metaData: Record<string, any> = {};
     inheritedMetaData: Record<string, any> = {};
     allMetaData: Record<string, any> = {};
+    internalMetaData: Record<string, any> = {};
 
     settings?: Record<string, any>;
 
@@ -62,6 +63,7 @@ export class Asset
         asset.parent = this;
 
         asset.inheritedMetaData = { ...this.inheritedMetaData, ...this.metaData };
+        asset.internalMetaData = { ...this.internalMetaData };
 
         asset.allMetaData = { ...asset.inheritedMetaData, ...asset.metaData };
     }
@@ -84,6 +86,7 @@ export class Asset
         asset.transformParent = this;
 
         asset.inheritedMetaData = { ...this.inheritedMetaData, ...this.metaData };
+        asset.internalMetaData = { ...this.internalMetaData };
 
         asset.allMetaData = { ...asset.inheritedMetaData, ...asset.metaData };
 

--- a/packages/core/src/Asset.ts
+++ b/packages/core/src/Asset.ts
@@ -31,7 +31,7 @@ export class Asset
     metaData: Record<string, any> = {};
     inheritedMetaData: Record<string, any> = {};
     allMetaData: Record<string, any> = {};
-    internalMetaData: Record<string, any> = {};
+    transformData: Record<string, any> = {};
 
     settings?: Record<string, any>;
 
@@ -63,7 +63,7 @@ export class Asset
         asset.parent = this;
 
         asset.inheritedMetaData = { ...this.inheritedMetaData, ...this.metaData };
-        asset.internalMetaData = { ...this.internalMetaData };
+        asset.transformData = { ...this.transformData };
 
         asset.allMetaData = { ...asset.inheritedMetaData, ...asset.metaData };
     }
@@ -86,7 +86,7 @@ export class Asset
         asset.transformParent = this;
 
         asset.inheritedMetaData = { ...this.inheritedMetaData, ...this.metaData };
-        asset.internalMetaData = { ...this.internalMetaData };
+        asset.transformData = { ...this.transformData };
 
         asset.allMetaData = { ...asset.inheritedMetaData, ...asset.metaData };
 

--- a/packages/core/src/pipes/mergePipeOptions.ts
+++ b/packages/core/src/pipes/mergePipeOptions.ts
@@ -1,9 +1,11 @@
-import type { Asset } from '../Asset';
-import type { AssetPipe } from './AssetPipe';
+import { merge } from '../utils/merge';
 
-export function mergePipeOptions<T>(pipe: AssetPipe<T>, asset: Asset): T
+import type { Asset } from '../Asset';
+import type { AssetPipe, PluginOptions } from './AssetPipe';
+
+export function mergePipeOptions<T extends PluginOptions<any>>(pipe: AssetPipe<T>, asset: Asset): T
 {
     if (!asset.settings) return pipe.defaultOptions;
 
-    return { ...pipe.defaultOptions, ...asset.settings };
+    return merge.recursive(pipe.defaultOptions, asset.settings);
 }

--- a/packages/ffmpeg/src/audio.ts
+++ b/packages/ffmpeg/src/audio.ts
@@ -34,5 +34,7 @@ export function audio(_options?: FfmpegOptions): AssetPipe
 
     const audio = ffmpeg(merge(true, defaultOptions, _options));
 
+    audio.name = 'audio';
+
     return audio;
 }

--- a/packages/spine/src/spineAtlasCompress.ts
+++ b/packages/spine/src/spineAtlasCompress.ts
@@ -11,7 +11,7 @@ export function spineAtlasCompress(_options?: SpineAtlasCompressOptions): AssetP
     const defaultOptions = {
         ..._options,
         tags: {
-            tps: 'nc',
+            nc: 'nc',
             ..._options?.tags
         }
     };

--- a/packages/texture-packer/src/texturePacker.ts
+++ b/packages/texture-packer/src/texturePacker.ts
@@ -175,7 +175,7 @@ export function texturePacker(_options: TexturePackerOptions = {}): AssetPipe<Te
 
                         textureAsset.metaData[tags.fix] = true;
 
-                        jsonAsset.internalMetaData.page = i;
+                        jsonAsset.transformData.page = i;
 
                         assets.push(textureAsset, jsonAsset);
                     }

--- a/packages/texture-packer/src/texturePacker.ts
+++ b/packages/texture-packer/src/texturePacker.ts
@@ -6,7 +6,7 @@ import { createNewAssetAt, Logger, path, stripTags } from '@play-co/assetpack-co
 import type { PackTexturesOptions, TexturePackerFormat } from './packer/packTextures';
 import type { Asset, AssetPipe, PluginOptions } from '@play-co/assetpack-core';
 
-export interface TexturePackerOptions extends PluginOptions<'tps' | 'fix' | 'jpg' | 'nc' >
+export interface TexturePackerOptions extends PluginOptions<'tps' | 'fix' | 'jpg' >
 {
     texturePacker?: Partial<PackTexturesOptions>;
     resolutionOptions?: {
@@ -66,7 +66,6 @@ export function texturePacker(_options: TexturePackerOptions = {}): AssetPipe<Te
             tps: 'tps',
             fix: 'fix',
             jpg: 'jpg',
-            nc: 'nc',
             ..._options.tags,
         }
     } as TexturePackerOptions;
@@ -95,13 +94,13 @@ export function texturePacker(_options: TexturePackerOptions = {}): AssetPipe<Te
             const fixedResolutions: {[x: string]: number} = {};
 
             // eslint-disable-next-line max-len
-            fixedResolutions[resolutionOptions.fixedResolution as any] = resolutionOptions.resolutions[resolutionOptions.fixedResolution];
+            fixedResolutions[resolutionOptions.fixedResolution] = resolutionOptions.resolutions[resolutionOptions.fixedResolution];
 
             // skip the children so that they do not get processed!
             asset.skipChildren();
 
             const largestResolution = Math.max(...Object.values(resolutionOptions.resolutions));
-            const resolutionHash = asset.allMetaData[tags.fix as any] ? fixedResolutions : resolutionOptions.resolutions;
+            const resolutionHash = asset.allMetaData[tags.fix] ? fixedResolutions : resolutionOptions.resolutions;
 
             const globPath = `${asset.path}/**/*.{jpg,png,gif}`;
             const files = await glob(globPath);
@@ -118,7 +117,7 @@ export function texturePacker(_options: TexturePackerOptions = {}): AssetPipe<Te
                 return { path: stripTags(path.relative(asset.path, f)), contents };
             }));
 
-            const textureFormat = (asset.metaData[tags.jpg as any] ? 'jpg' : 'png') as TexturePackerFormat;
+            const textureFormat = (asset.metaData[tags.jpg] ? 'jpg' : 'png') as TexturePackerFormat;
 
             const texturePackerOptions = {
                 ...texturePacker,
@@ -176,7 +175,7 @@ export function texturePacker(_options: TexturePackerOptions = {}): AssetPipe<Te
 
                         textureAsset.metaData[tags.fix] = true;
 
-                        jsonAsset.metaData.page = i;
+                        jsonAsset.internalMetaData.page = i;
 
                         assets.push(textureAsset, jsonAsset);
                     }

--- a/packages/texture-packer/src/texturePackerCacheBuster.ts
+++ b/packages/texture-packer/src/texturePackerCacheBuster.ts
@@ -1,7 +1,9 @@
 import { removeSync, writeFileSync } from 'fs-extra';
 import { type AssetPipe, checkExt, findAssets } from '@play-co/assetpack-core';
 
-import type { Asset } from '@play-co/assetpack-core';
+import type { Asset, PluginOptions } from '@play-co/assetpack-core';
+
+export type TexturePackerCacheBustOptions = PluginOptions<'tps'>;
 
 /**
  * This should be used after the cache buster plugin in the pipes.
@@ -17,9 +19,16 @@ import type { Asset } from '@play-co/assetpack-core';
  * @param _options
  * @returns
  */
-export function texturePackerCacheBuster(): AssetPipe
+export function texturePackerCacheBuster(
+    _options: TexturePackerCacheBustOptions = {}
+): AssetPipe<TexturePackerCacheBustOptions>
 {
-    const defaultOptions = {};
+    const defaultOptions = {
+        tags: {
+            tps: 'tps',
+            ..._options.tags,
+        },
+    };
 
     const textureJsonFilesToFix: Asset[] = [];
 
@@ -27,9 +36,9 @@ export function texturePackerCacheBuster(): AssetPipe
         folder: false,
         name: 'texture-packer-cache-buster',
         defaultOptions,
-        test(asset: Asset, _options)
+        test(asset: Asset, options)
         {
-            return asset.allMetaData.tps && checkExt(asset.path, '.json');
+            return asset.allMetaData[options.tags.tps] && checkExt(asset.path, '.json');
         },
 
         async transform(asset: Asset, _options)

--- a/packages/texture-packer/src/texturePackerManifestMod.ts
+++ b/packages/texture-packer/src/texturePackerManifestMod.ts
@@ -1,9 +1,9 @@
 import { existsSync, readJsonSync, writeJSONSync } from 'fs-extra';
 import { type AssetPipe, findAssets, path } from '@play-co/assetpack-core';
 
-import type { Asset } from '@play-co/assetpack-core';
+import type { Asset, PluginOptions } from '@play-co/assetpack-core';
 
-export interface TexturePackerManifestOptions
+export interface TexturePackerManifestOptions extends PluginOptions<'tps'>
 {
     output?: string;
 }
@@ -34,7 +34,11 @@ export function texturePackerManifestMod(
 {
     const defaultOptions = {
         output: 'manifest.json',
-        ..._options
+        ..._options,
+        tags: {
+            tps: 'tps',
+            ..._options.tags,
+        },
     };
 
     return {
@@ -63,7 +67,7 @@ export function texturePackerManifestMod(
             const duplicateHash: Record<string, boolean> = {};
 
             const originalJsonAssets = findAssets((asset) =>
-                asset.metaData.tps && !asset.transformParent, asset, true);
+                asset.metaData[options.tags.tps] && !asset.transformParent, asset, true);
 
             originalJsonAssets.forEach((originalJsonAsset) =>
             {
@@ -120,9 +124,9 @@ function getTexturePackedAssets(assets: Asset[])
     {
         const jsonAsset = jsonAssets[i];
 
-        groupAssets[jsonAsset.allMetaData.page] ??= [];
+        groupAssets[jsonAsset.internalMetaData.page] ??= [];
 
-        groupAssets[jsonAsset.allMetaData.page].push(jsonAsset);
+        groupAssets[jsonAsset.internalMetaData.page].push(jsonAsset);
     }
 
     return groupAssets;

--- a/packages/texture-packer/src/texturePackerManifestMod.ts
+++ b/packages/texture-packer/src/texturePackerManifestMod.ts
@@ -124,9 +124,9 @@ function getTexturePackedAssets(assets: Asset[])
     {
         const jsonAsset = jsonAssets[i];
 
-        groupAssets[jsonAsset.internalMetaData.page] ??= [];
+        groupAssets[jsonAsset.transformData.page] ??= [];
 
-        groupAssets[jsonAsset.internalMetaData.page].push(jsonAsset);
+        groupAssets[jsonAsset.transformData.page].push(jsonAsset);
     }
 
     return groupAssets;

--- a/packages/webfont/src/sdf.ts
+++ b/packages/webfont/src/sdf.ts
@@ -6,7 +6,7 @@ import { checkExt, createNewAssetAt, stripTags } from '@play-co/assetpack-core';
 import type { BitmapFontOptions } from 'msdf-bmfont-xml';
 import type { Asset, AssetPipe, PluginOptions } from '@play-co/assetpack-core';
 
-export interface SDFFontOptions extends PluginOptions<'sdf'>
+export interface SDFFontOptions extends PluginOptions<'font' | 'nc' | 'fix'>
 {
     name: string,
     type: BitmapFontOptions['fieldType'],
@@ -23,7 +23,7 @@ export function signedFont(
         defaultOptions,
         test(asset: Asset, options)
         {
-            return asset.allMetaData[options.type] && checkExt(asset.path, '.ttf');
+            return asset.allMetaData[options.tags.font] && checkExt(asset.path, '.ttf');
         },
         async transform(asset: Asset, options)
         {
@@ -46,8 +46,8 @@ export function signedFont(
                 const newTextureAsset = createNewAssetAt(asset, newTextureName);
 
                 // don't compress!
-                newTextureAsset.metaData.nc = true;
-                newTextureAsset.metaData.fix = true;
+                newTextureAsset.metaData[options.tags.nc] = true;
+                newTextureAsset.metaData[options.tags.fix] = true;
 
                 assets.push(newTextureAsset);
 
@@ -72,16 +72,28 @@ export function sdfFont(options: Partial<SDFFontOptions> = {}): AssetPipe
     return signedFont({
         name: 'sdf-font',
         type: 'sdf',
-        ...options
+        ...options,
+        tags: {
+            font: 'sdf',
+            nc: 'nc',
+            fix: 'fix',
+            ...options.tags
+        }
     });
 }
 
-export function msdfFont(options?: Partial<SDFFontOptions>): AssetPipe
+export function msdfFont(options: Partial<SDFFontOptions> = {}): AssetPipe
 {
     return signedFont({
         name: 'msdf-font',
         type: 'msdf',
         ...options,
+        tags: {
+            font: 'msdf',
+            nc: 'nc',
+            fix: 'fix',
+            ...options.tags
+        }
     });
 }
 

--- a/packages/webfont/src/webfont.ts
+++ b/packages/webfont/src/webfont.ts
@@ -1,14 +1,17 @@
 import { fonts } from './fonts';
 import { checkExt, createNewAssetAt, path } from '@play-co/assetpack-core';
 
-import type { Asset, AssetPipe } from '@play-co/assetpack-core';
+import type { Asset, AssetPipe, PluginOptions } from '@play-co/assetpack-core';
 
-export function webfont(): AssetPipe
+export type WebfontOptions = PluginOptions<'wf'>;
+
+export function webfont(_options?: Partial<WebfontOptions>): AssetPipe<WebfontOptions>
 {
-    const defaultOptions = {
+    const defaultOptions: WebfontOptions = {
         tags: {
             wf: 'wf',
-        }
+            ..._options?.tags
+        },
     };
 
     return {
@@ -17,7 +20,7 @@ export function webfont(): AssetPipe
         defaultOptions,
         test(asset: Asset, options)
         {
-            return asset.metaData[options.tags.wf as any] && checkExt(asset.path, '.otf', '.ttf', '.svg');
+            return asset.allMetaData[options.tags.wf] && checkExt(asset.path, '.otf', '.ttf', '.svg');
         },
         async transform(asset: Asset)
         {


### PR DESCRIPTION
ensures that the correct tags are being used everywhere
also adds `internalMetaData` to allow plugins to add stuff without affecting the user generated metadata and tags