### PR TITLE
fix(texture-packer): generating wrong alias

### DIFF
--- a/packages/texture-packer/src/texturePackerManifestMod.ts
+++ b/packages/texture-packer/src/texturePackerManifestMod.ts
@@ -86,14 +86,17 @@ export function texturePackerManifestMod(
 
                 const { manifestAsset, bundle } = findManifestAsset(manifest, jsonManifestPath);
 
+                const texturePackedAssets = getTexturePackedAssets(finalJsonAssets);
+
                 // now we need to get the pages of the sprite sheet and update the manifest with the new pages.
-                getTexturePackedAssets(finalJsonAssets).forEach((pages, pageIndex) =>
+                texturePackedAssets.forEach((pages, pageIndex) =>
                 {
                     bundle.assets.push({
                         // use the same alias as the original asset but add the page index to it.
                         // we don't control what the alias is so we use whats here.
-                        alias: manifestAsset.alias.map((alias: string[]) =>
-                            `${alias}-${pageIndex}`),
+                        alias: manifestAsset.alias.map((alias: string) =>
+                            getAlias(alias, pageIndex, texturePackedAssets.length > 1)
+                        ),
                         src: pages
                             .map((finalAsset) => path.relative(pipeSystem.outputPath, finalAsset.path))
                             .sort((a, b) => b.localeCompare(a)),
@@ -151,4 +154,14 @@ function findManifestAsset(manifest: any, assetPath: string): {bundle: any, mani
     }
 
     return { bundle: null, manifestAsset: null };
+}
+
+function getAlias(alias: string, pageIndex: number, multiPage: boolean)
+{
+    if (multiPage)
+    {
+        return `${alias}-${pageIndex}`;
+    }
+
+    return alias;
 }

--- a/packages/texture-packer/test/texturePackerManifest.test.ts
+++ b/packages/texture-packer/test/texturePackerManifest.test.ts
@@ -1,3 +1,4 @@
+import { readJSONSync } from 'fs-extra';
 import { assetPath, createFolder, getInputDir, getOutputDir } from '../../../shared/test/index';
 import { texturePackerManifestMod } from '../src/texturePackerManifestMod';
 import { AssetPack } from '@play-co/assetpack-core';
@@ -52,6 +53,50 @@ describe('Texture Packer Compression', () =>
                 texturePacker({
                     resolutionOptions: {
                         resolutions: { default: 1 },
+                    },
+                }),
+                pixiManifest(),
+                texturePackerManifestMod(),
+            ]
+        });
+
+        await assetpack.run();
+
+        const manifest = readJSONSync(`${outputDir}/manifest.json`);
+
+        expect(manifest.bundles[0].assets[0]).toEqual({
+
+            alias: [
+                'sprites'
+            ],
+            src: [
+                'sprites.json'
+            ],
+            data: {
+                tags: {
+                    tps: true
+                }
+            }
+
+        });
+    });
+
+    it('should create a multi page sprite sheet', async () =>
+    {
+        const testName = 'tp-manifest-multi-page';
+        const inputDir = getInputDir(pkg, testName);
+        const outputDir = getOutputDir(pkg, testName);
+
+        genFolder(testName);
+
+        const assetpack = new AssetPack({
+            entry: inputDir,
+            output: outputDir,
+            cache: false,
+            pipes: [
+                texturePacker({
+                    resolutionOptions: {
+                        resolutions: { default: 1 },
                         maximumTextureSize: 512
                     },
                 }),
@@ -62,10 +107,35 @@ describe('Texture Packer Compression', () =>
 
         await assetpack.run();
 
-        // const sheetPng = readJSONSync(`${outputDir}/sprites.png.json`);
-        // const sheetWebp = readJSONSync(`${outputDir}/sprites.webp.json`);
+        const manifest = readJSONSync(`${outputDir}/manifest.json`);
 
-        // expect(sheetPng.meta.image).toEqual(`sprites.png`);
-        // expect(sheetWebp.meta.image).toEqual(`sprites.webp`);
+        expect(manifest.bundles[0].assets).toEqual([
+            {
+                alias: [
+                    'sprites-0'
+                ],
+                src: [
+                    'sprites-0.json'
+                ],
+                data: {
+                    tags: {
+                        tps: true
+                    }
+                }
+            },
+            {
+                alias: [
+                    'sprites-1'
+                ],
+                src: [
+                    'sprites-1.json'
+                ],
+                data: {
+                    tags: {
+                        tps: true
+                    }
+                }
+            }
+        ]);
     });
 });


### PR DESCRIPTION
corrects alias when a single texture packer page is created. 