### PR TITLE
chore: change tag overrides

### DIFF
--- a/src/core/pipes/AssetPipe.ts
+++ b/src/core/pipes/AssetPipe.ts
@@ -15,12 +15,9 @@ export type DeepRequired<T> = T extends Primitive
                 ? DeepRequired<U2>
                 : DeepRequired<T[P]>
     };
-export interface PluginOptions<T extends string>
-{
-    tags?: Partial<Record<T, string>>;
-}
+export interface PluginOptions {}
 
-export interface AssetPipe<OPTIONS=Record<string, any>>
+export interface AssetPipe<OPTIONS=Record<string, any>, TAGS extends string = string>
 {
     /** Whether the process runs on a folder */
     folder?: boolean;
@@ -28,7 +25,11 @@ export interface AssetPipe<OPTIONS=Record<string, any>>
     /** Name of the plugin used to tell the manifest parsers which one to use */
     name: string;
 
+    /** Default options for the plugin */
     defaultOptions: OPTIONS;
+
+    /** Tags that can be used to control the plugin */
+    tags?: Record<TAGS, string>;
 
     /**
      * Called once at the start.

--- a/src/core/pipes/mergePipeOptions.ts
+++ b/src/core/pipes/mergePipeOptions.ts
@@ -3,7 +3,7 @@ import { merge } from '../utils/merge.js';
 import type { Asset } from '../Asset.js';
 import type { AssetPipe, PluginOptions } from './AssetPipe.js';
 
-export function mergePipeOptions<T extends PluginOptions<any>>(pipe: AssetPipe<T>, asset: Asset): T | false
+export function mergePipeOptions<T extends PluginOptions>(pipe: AssetPipe<T>, asset: Asset): T | false
 {
     if (!asset.settings) return pipe.defaultOptions;
 

--- a/src/image/compress.ts
+++ b/src/image/compress.ts
@@ -11,7 +11,7 @@ type CompressWebpOptions = Omit<WebpOptions, 'force'>;
 type CompressAvifOptions = Omit<AvifOptions, 'force'>;
 type CompressPngOptions = Omit<PngOptions, 'force'>;
 
-export interface CompressOptions extends PluginOptions<'nc'>
+export interface CompressOptions extends PluginOptions
 {
     png?: CompressPngOptions | boolean;
     webp?: CompressWebpOptions | boolean;
@@ -26,7 +26,7 @@ export interface CompressImageData
     sharpImage: sharp.Sharp;
 }
 
-export function compress(options: CompressOptions = {}): AssetPipe<CompressOptions>
+export function compress(options: CompressOptions = {}): AssetPipe<CompressOptions, 'nc'>
 {
     const compress = resolveOptions<CompressOptions>(options, {
         png: true,
@@ -52,25 +52,22 @@ export function compress(options: CompressOptions = {}): AssetPipe<CompressOptio
         });
     }
 
-    const defaultOptions = {
-        ...compress,
-        tags: {
-            nc: 'nc',
-            ...options.tags,
-        }
-    };
-
     return {
         folder: true,
         name: 'compress',
-        defaultOptions,
+        defaultOptions: {
+            ...compress,
+        },
+        tags: {
+            nc: 'nc',
+        },
         test(asset: Asset, options)
         {
-            return options && checkExt(asset.path, '.png', '.jpg', '.jpeg') && !asset.allMetaData[options.tags.nc as any];
+            return options && checkExt(asset.path, '.png', '.jpg', '.jpeg') && !asset.allMetaData[this.tags!.nc];
         },
         async transform(asset: Asset, options)
         {
-            const shouldCompress = compress && !asset.metaData[options.tags.nc as any];
+            const shouldCompress = compress && !asset.metaData.nc;
 
             if (!shouldCompress)
             {

--- a/src/json/index.ts
+++ b/src/json/index.ts
@@ -1,26 +1,19 @@
 import { checkExt, createNewAssetAt, Logger } from '../core/index.js';
 
-import type { Asset, AssetPipe, PluginOptions } from '../core/index.js';
+import type { Asset, AssetPipe } from '../core/index.js';
 
-export type JsonOptions = PluginOptions<'nc'>;
-
-export function json(_options: JsonOptions = {}): AssetPipe
+export function json(): AssetPipe<any, 'nc'>
 {
-    const defaultOptions = {
-        tags: {
-            nc: 'nc',
-            ..._options?.tags
-        }
-
-    };
-
     return {
         name: 'json',
         folder: false,
-        defaultOptions,
-        test(asset: Asset, options)
+        defaultOptions: null,
+        tags: {
+            nc: 'nc',
+        },
+        test(asset: Asset)
         {
-            return !asset.metaData[options.tags.nc] && checkExt(asset.path, '.json');
+            return !asset.metaData[this.tags!.nc] && checkExt(asset.path, '.json');
         },
         async transform(asset: Asset)
         {

--- a/src/manifest/pixiManifest.ts
+++ b/src/manifest/pixiManifest.ts
@@ -137,6 +137,8 @@ function collectAssets(
 
         if (nonIgnored.length === 0) return;
 
+        if (nonIgnored.length === 0) return;
+
         bundleAssets.push({
             alias: getShortNames(stripTags(path.relative(entryPath, asset.path)), options),
             src: nonIgnored

--- a/src/pixi/index.ts
+++ b/src/pixi/index.ts
@@ -14,6 +14,7 @@ import { texturePackerCacheBuster } from '../texture-packer/texturePackerCacheBu
 import { texturePackerCompress } from '../texture-packer/texturePackerCompress.js';
 import { webfont } from '../webfont/webfont.js';
 
+import type { AssetPipe } from '../core/index.js';
 import type { FfmpegOptions } from '../ffmpeg/ffmpeg.js';
 import type { CompressOptions } from '../image/compress.js';
 import type { PixiManifestOptions } from '../manifest/pixiManifest.js';
@@ -80,7 +81,7 @@ export function pixiAssetPackPipes(config: PixiAssetPack)
         mipmap({
             resolutions: apConfig.resolutions as Record<string, number>,
         }),
-    ];
+    ] as AssetPipe[];
 
     if (apConfig.compression !== false)
     {

--- a/src/spine/spineAtlasCompress.ts
+++ b/src/spine/spineAtlasCompress.ts
@@ -1,32 +1,29 @@
 import { checkExt, createNewAssetAt, swapExt } from '../core/index.js';
 import { AtlasView } from './AtlasView.js';
 
-import type { Asset, AssetPipe, PluginOptions } from '../core/index.js';
+import type { Asset, AssetPipe } from '../core/index.js';
 import type { CompressOptions } from '../image/index.js';
 
-export type SpineAtlasCompressOptions = PluginOptions<'nc'> & Omit<CompressOptions, 'jpg'>;
+export type SpineAtlasCompressOptions = Omit<CompressOptions, 'jpg'>;
 
-export function spineAtlasCompress(_options?: SpineAtlasCompressOptions): AssetPipe<SpineAtlasCompressOptions>
+export function spineAtlasCompress(_options?: SpineAtlasCompressOptions): AssetPipe<SpineAtlasCompressOptions, 'nc'>
 {
-    const defaultOptions = {
-        ...{
-            png: true,
-            webp: true,
-            avif: false,
-        },
-        ..._options,
-        tags: {
-            nc: 'nc',
-            ..._options?.tags
-        }
-    };
-
     return {
         name: 'spine-atlas-compress',
-        defaultOptions,
-        test(asset: Asset, options)
+        defaultOptions: {
+            ...{
+                png: true,
+                webp: true,
+                avif: false,
+            },
+            ..._options,
+        },
+        tags: {
+            nc: 'nc',
+        },
+        test(asset: Asset)
         {
-            return !asset.allMetaData[options.tags.nc]
+            return !asset.allMetaData[this.tags!.nc]
                 && checkExt(asset.path, '.atlas');
         },
         async transform(asset: Asset, options)

--- a/src/spine/spineAtlasMipmap.ts
+++ b/src/spine/spineAtlasMipmap.ts
@@ -3,28 +3,25 @@ import { checkExt, createNewAssetAt } from '../core/index.js';
 import type { Asset, AssetPipe, PluginOptions } from '../core/index.js';
 import type { MipmapOptions } from '../image/index.js';
 
-export type SpineOptions = PluginOptions<'fix'> & MipmapOptions;
+export type SpineOptions = PluginOptions & MipmapOptions;
 
-export function spineAtlasMipmap(_options?: SpineOptions): AssetPipe<SpineOptions>
+export function spineAtlasMipmap(_options?: SpineOptions): AssetPipe<SpineOptions, 'fix'>
 {
-    const defaultOptions = {
-        template: '@%%x',
-        resolutions: { default: 1, low: 0.5 },
-        fixedResolution: 'default',
-        ..._options,
-        tags: {
-            fix: 'fix',
-            ..._options?.tags
-        },
-    };
-
     return {
         folder: false,
         name: 'mipmap-spine-atlas',
-        defaultOptions,
-        test(asset: Asset, options)
+        defaultOptions: {
+            template: '@%%x',
+            resolutions: { default: 1, low: 0.5 },
+            fixedResolution: 'default',
+            ..._options,
+        },
+        tags: {
+            fix: 'fix',
+        },
+        test(asset: Asset)
         {
-            return !asset.allMetaData[options.tags.fix as any] && checkExt(asset.path, '.atlas');
+            return !asset.allMetaData[this.tags!.fix] && checkExt(asset.path, '.atlas');
         },
         async transform(asset: Asset, options)
         {
@@ -33,7 +30,7 @@ export function spineAtlasMipmap(_options?: SpineOptions): AssetPipe<SpineOption
             fixedResolutions[options.fixedResolution] = options.resolutions[options.fixedResolution];
 
             const largestResolution = Math.max(...Object.values(options.resolutions));
-            const resolutionHash = asset.allMetaData[options.tags.fix as any] ? fixedResolutions : options.resolutions;
+            const resolutionHash = asset.allMetaData[this.tags!.fix] ? fixedResolutions : options.resolutions;
 
             const rawAtlas = asset.buffer.toString();
 

--- a/src/texture-packer/packer/createJsons.ts
+++ b/src/texture-packer/packer/createJsons.ts
@@ -61,6 +61,17 @@ export function createJsons(
             };
         }
 
+        const name = createName(options.textureName, i, bins.length !== 1, options.resolution, options.textureFormat);
+
+        let multiPack: string[] | null = null;
+
+        if (bins.length > 1 && i === 0)
+        {
+            const binsWithoutFirst = bins.slice(1);
+
+            multiPack = binsWithoutFirst.map((_, i) => name.replace('-0', `-${i + 1}`).replace('.png', `.json`));
+        }
+
         json.meta = {
             app: 'http://github.com/pixijs/assetpack',
             version: '1.0',

--- a/src/texture-packer/packer/createJsons.ts
+++ b/src/texture-packer/packer/createJsons.ts
@@ -61,17 +61,6 @@ export function createJsons(
             };
         }
 
-        const name = createName(options.textureName, i, bins.length !== 1, options.resolution, options.textureFormat);
-
-        let multiPack: string[] | null = null;
-
-        if (bins.length > 1 && i === 0)
-        {
-            const binsWithoutFirst = bins.slice(1);
-
-            multiPack = binsWithoutFirst.map((_, i) => name.replace('-0', `-${i + 1}`).replace('.png', `.json`));
-        }
-
         json.meta = {
             app: 'http://github.com/pixijs/assetpack',
             version: '1.0',

--- a/src/texture-packer/texturePackerCacheBuster.ts
+++ b/src/texture-packer/texturePackerCacheBuster.ts
@@ -1,9 +1,7 @@
 import fs from 'fs-extra';
 import { checkExt, findAssets } from '../core/index.js';
 
-import type { Asset, AssetPipe, PluginOptions } from '../core/index.js';
-
-export type TexturePackerCacheBustOptions = PluginOptions<'tps'>;
+import type { Asset, AssetPipe } from '../core/index.js';
 
 /**
  * This should be used after the cache buster plugin in the pipes.
@@ -16,29 +14,22 @@ export type TexturePackerCacheBustOptions = PluginOptions<'tps'>;
  *
  * Kind of like applying a patch at the end of the transform process.
  *
- * @param _options
  * @returns
  */
-export function texturePackerCacheBuster(
-    _options: TexturePackerCacheBustOptions = {}
-): AssetPipe<TexturePackerCacheBustOptions>
+export function texturePackerCacheBuster(): AssetPipe<any, 'tps'>
 {
-    const defaultOptions = {
-        tags: {
-            tps: 'tps',
-            ..._options.tags,
-        },
-    };
-
     const textureJsonFilesToFix: Asset[] = [];
 
     return {
         folder: false,
         name: 'texture-packer-cache-buster',
-        defaultOptions,
-        test(asset: Asset, options)
+        defaultOptions: null,
+        tags: {
+            tps: 'tps',
+        },
+        test(asset: Asset)
         {
-            return asset.allMetaData[options.tags.tps] && checkExt(asset.path, '.json');
+            return asset.allMetaData[this.tags!.tps] && checkExt(asset.path, '.json');
         },
 
         async transform(asset: Asset, _options)

--- a/src/texture-packer/texturePackerCompress.ts
+++ b/src/texture-packer/texturePackerCompress.ts
@@ -1,36 +1,33 @@
 import { checkExt, createNewAssetAt, swapExt } from '../core/index.js';
 
-import type { Asset, AssetPipe, PluginOptions } from '../core/index.js';
+import type { Asset, AssetPipe } from '../core/index.js';
 import type { CompressOptions } from '../image/compress.js';
 
-export type TexturePackerCompressOptions = PluginOptions<'tps' | 'nc'> & Omit<CompressOptions, 'jpg'>;
+export type TexturePackerCompressOptions = Omit<CompressOptions, 'jpg'>;
 
 export function texturePackerCompress(
     _options?: TexturePackerCompressOptions,
-): AssetPipe<TexturePackerCompressOptions>
+): AssetPipe<TexturePackerCompressOptions, 'tps' | 'nc'>
 {
-    const defaultOptions = {
-        ...{
-            png: true,
-            webp: true,
-            avif: false,
+    return {
+        name: 'texture-packer-compress',
+        defaultOptions: {
+            ...{
+                png: true,
+                webp: true,
+                avif: false,
+            },
+            ..._options,
         },
-        ..._options,
         tags: {
             tps: 'tps',
             nc: 'nc',
-            ..._options?.tags,
         },
-    };
-
-    return {
-        name: 'texture-packer-compress',
-        defaultOptions,
-        test(asset: Asset, options)
+        test(asset: Asset)
         {
             return (
-                asset.allMetaData[options.tags.tps]
-                && !asset.allMetaData[options.tags.nc]
+                asset.allMetaData[this.tags!.tps]
+                && !asset.allMetaData[this.tags!.nc]
                 && checkExt(asset.path, '.json')
             );
         },

--- a/src/webfont/webfont.ts
+++ b/src/webfont/webfont.ts
@@ -1,26 +1,20 @@
 import { checkExt, createNewAssetAt, path } from '../core/index.js';
 import { fonts } from './fonts.js';
 
-import type { Asset, AssetPipe, PluginOptions } from '../core/index.js';
+import type { Asset, AssetPipe } from '../core/index.js';
 
-export type WebfontOptions = PluginOptions<'wf'>;
-
-export function webfont(_options?: Partial<WebfontOptions>): AssetPipe<WebfontOptions>
+export function webfont(): AssetPipe<null, 'wf'>
 {
-    const defaultOptions: WebfontOptions = {
-        tags: {
-            wf: 'wf',
-            ..._options?.tags
-        },
-    };
-
     return {
         folder: false,
         name: 'webfont',
-        defaultOptions,
-        test(asset: Asset, options)
+        defaultOptions: null,
+        tags: {
+            wf: 'wf',
+        },
+        test(asset: Asset)
         {
-            return asset.allMetaData[options.tags.wf] && checkExt(asset.path, '.otf', '.ttf', '.svg');
+            return asset.allMetaData[this.tags!.wf] && checkExt(asset.path, '.otf', '.ttf', '.svg');
         },
         async transform(asset: Asset)
         {

--- a/src/webfont/webfont.ts
+++ b/src/webfont/webfont.ts
@@ -3,7 +3,7 @@ import { fonts } from './fonts.js';
 
 import type { Asset, AssetPipe } from '../core/index.js';
 
-export function webfont(): AssetPipe<null, 'wf'>
+export function webfont(): AssetPipe<any, 'wf'>
 {
     return {
         folder: false,

--- a/test/core/Assetpack.test.ts
+++ b/test/core/Assetpack.test.ts
@@ -54,13 +54,13 @@ describe('Core', () =>
             start: true,
             finish: true,
             transform: true,
-        }) as MockAssetPipe;
+        }) as unknown as MockAssetPipe;
 
         const assetpack = new AssetPack({
             entry: inputDir, cacheLocation: getCacheDir(pkg, testName),
             output: outputDir,
             pipes: [
-                plugin as AssetPipe<any>,
+                plugin as unknown as AssetPipe,
             ],
             cache: false,
         });
@@ -315,13 +315,13 @@ describe('Core', () =>
             start: true,
             finish: true,
             transform: true,
-        }) as MockAssetPipe;
+        });
 
         const assetpack = new AssetPack({
             entry: inputDir, cacheLocation: getCacheDir(pkg, testName),
             output: outputDir,
             pipes: [
-                plugin as AssetPipe<any>,
+                plugin
             ],
             cache: false,
             assetSettings: [

--- a/test/texture-packer/texturePacker.test.ts
+++ b/test/texture-packer/texturePacker.test.ts
@@ -213,19 +213,19 @@ describe('Texture Packer', () =>
                 ],
             });
 
+        const tps = texturePacker({
+            resolutionOptions: {
+                resolutions: { default: 1 },
+            },
+        });
+
+        tps.tags!.tps = 'random';
         const assetpack = new AssetPack({
             entry: inputDir, cacheLocation: getCacheDir(pkg, testName),
             output: outputDir,
             cache: false,
             pipes: [
-                texturePacker({
-                    resolutionOptions: {
-                        resolutions: { default: 1 },
-                    },
-                    tags: {
-                        tps: 'random',
-                    }
-                })
+                tps
             ]
         });
 

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -88,6 +88,7 @@ export function createAssetPipe(
         folder: data.folder || false,
         name: name ?? 'test',
         defaultOptions: {},
+        tags: {},
         test: convert('test'),
         transform: convert('transform'),
         start: convert('start'),


### PR DESCRIPTION
i've simplified down how we can override tags. Its now just an object on the plugin which a user can change if they want. The main difference here is that you can no longer change the tag per asset, which i don't think is needed